### PR TITLE
Fix hierarchy showing different data for source versions vs HEAD

### DIFF
--- a/src/components/search/ConceptHierarchyResultsTable.jsx
+++ b/src/components/search/ConceptHierarchyResultsTable.jsx
@@ -37,7 +37,18 @@ const getValue = (item, column) => {
   return value
 }
 
-const Row = ({ item, columns, isSelected, onSelectChange, containerOnSelectChange, selectedList, level }) => {
+const getVersionedChildrenURL = (item, baseURL) => {
+  if(!baseURL)
+    return item.url + 'children/'
+  // baseURL is like /users/foo/sources/Bar/1.0/concepts/
+  // item.url is like /users/foo/sources/Bar/concepts/FOOD_001/
+  // We need: /users/foo/sources/Bar/1.0/concepts/FOOD_001/children/
+  const conceptsSuffix = item.url.replace(/^.*\/concepts\//, 'concepts/').replace(/\/$/, '')
+  const sourcePrefix = baseURL.replace(/concepts\/.*$/, '')
+  return sourcePrefix + conceptsSuffix + '/children/'
+}
+
+const Row = ({ item, columns, isSelected, onSelectChange, containerOnSelectChange, selectedList, level, baseURL }) => {
   const [open, setOpen] = React.useState(false);
   const [children, setChildren] = React.useState([]);
   const [selected, setSelected] = React.useState(isSelected);
@@ -77,7 +88,8 @@ const Row = ({ item, columns, isSelected, onSelectChange, containerOnSelectChang
 
   const fetchChildren = () => {
     if(!fetched) {
-      APIService.new().overrideURL(item.url).appendToUrl('children/').get().then(response => {
+      const childrenURL = getVersionedChildrenURL(item, baseURL)
+      APIService.new().overrideURL(childrenURL).get().then(response => {
         setChildren(response.data || [])
         setFetched(true)
       })
@@ -136,6 +148,7 @@ const Row = ({ item, columns, isSelected, onSelectChange, containerOnSelectChang
                           containerOnSelectChange={containerOnSelectChange}
                           columns={columns}
                           level={level + 1}
+                          baseURL={baseURL}
                         />
                       ))
                     )
@@ -152,7 +165,7 @@ const Row = ({ item, columns, isSelected, onSelectChange, containerOnSelectChang
 
 const ConceptHierarchyResultsTable = ({
   results, onPageChange, onSelect, onSelectChange, viewFields,
-  onCreateSimilarClick, onCreateMappingClick
+  onCreateSimilarClick, onCreateMappingClick, baseURL
 }) => {
   const [selectedList, setSelectedList] = React.useState([]);
   const resourceDefinition = CONCEPTS_DEFINITION;
@@ -236,6 +249,7 @@ const ConceptHierarchyResultsTable = ({
                         containerOnSelectChange={onSelectChange}
                         columns={columns}
                         level={0}
+                        baseURL={baseURL}
                       />
                     ))
                   }

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -937,6 +937,7 @@ class Search extends React.Component {
                     onCreateMappingClick={onCreateMappingClick}
                     viewFields={viewFields}
                     onSelect={onSelect}
+                    baseURL={this.prepareBaseURL()}
                   /> : (
                     isTable ?
                     <ResultsTable


### PR DESCRIPTION
## Summary
- Fixes hierarchy tree expansion always fetching children from HEAD instead of the viewed source version
- Passes versioned `baseURL` from Search into `ConceptHierarchyResultsTable` and reconstructs children fetch URLs to include the source version
- Falls back to existing behavior when no `baseURL` is provided

Closes OpenConceptLab/ocl_issues#2149

## Test plan
- [ ] View a source with hierarchy enabled at HEAD — hierarchy should work as before
- [ ] Create a source version, then view its hierarchy — tree expansion should show the same hierarchy as HEAD (assuming no content changes)
- [ ] Verify that expanding child nodes in a versioned source fetches from the versioned API endpoint (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)