### PR TITLE
feat: Add Changelog Viewer to Concept Version List      

### DIFF
--- a/src/components/common/ChangelogMarkdown.jsx
+++ b/src/components/common/ChangelogMarkdown.jsx
@@ -1,0 +1,110 @@
+/* eslint-disable spellcheck/spell-checker */
+import React from 'react';
+import ReactMarkdown from 'react-markdown'
+import gfm from 'remark-gfm'
+import { get } from 'lodash';
+import './CustomMarkdown.scss'
+
+const getNodeText = children => React.Children.toArray(children).map(child => {
+  if(typeof child === 'string')
+    return child
+  return getNodeText(get(child, 'props.children', ''))
+}).join('')
+
+const slugifyHeading = text => text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-')
+
+const normalizeChangelogMarkdown = markdown => {
+  const headings = []
+  let pendingAnchor = null
+  const markdownWithInlineAnchors = (markdown || '').replace(
+    /<a\s+id=["']([^"']+)["']><\/a>(\[[^\]]+\]\([^)]+\))/gi,
+    (_, id, link) => link.replace(/\)$/, ` "anchor:${id}")`)
+  )
+  const normalizedMarkdown = markdownWithInlineAnchors.split('\n').filter(line => {
+    const anchorMatch = line.trim().match(/^<a\s+id=["']([^"']+)["']><\/a>$/i)
+    if(anchorMatch) {
+      pendingAnchor = anchorMatch[1]
+      return false
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/)
+    if(headingMatch) {
+      headings.push({level: headingMatch[1].length, id: pendingAnchor})
+      pendingAnchor = null
+    }
+
+    return true
+  }).join('\n')
+
+  return {markdown: normalizedMarkdown, headings}
+}
+
+const ChangelogMarkdown = ({markdown}) => {
+  const {markdown: normalizedMarkdown, headings} = React.useMemo(() => normalizeChangelogMarkdown(markdown), [markdown])
+  let headingIndex = 0
+  const renderHeading = level => props => {
+    const children = props.children
+    const rest = {...props}
+    delete rest.node
+    delete rest.children
+    const heading = headings[headingIndex] || {}
+    const Tag = `h${level}`
+    const id = heading.id || slugifyHeading(getNodeText(children))
+    headingIndex += 1
+
+    return <Tag id={id || undefined} style={id ? {scrollMarginTop: '16px'} : {}} {...rest}>{children}</Tag>
+  }
+  const renderLink = props => {
+    const {href, children, title} = props
+    const rest = {...props}
+    delete rest.node
+    delete rest.href
+    delete rest.children
+    delete rest.title
+    const anchor = title && title.startsWith('anchor:') ? title.replace('anchor:', '') : null
+    if(href && href.startsWith('#')) {
+      return (
+        <a
+          href={href}
+          {...rest}
+          onClick={event => {
+            const target = document.getElementById(href.slice(1))
+            if(target) {
+              event.preventDefault()
+              target.scrollIntoView({behavior: 'smooth', block: 'start'})
+            }
+          }}
+        >
+          {children}
+        </a>
+      )
+    }
+
+    if(href && href.match(/^https?:\/\//i))
+      return <a id={anchor || undefined} href={href} target='_blank' rel='noopener noreferrer' {...rest}>{children}</a>
+
+    return <a id={anchor || undefined} href={href} {...rest}>{children}</a>
+  }
+
+  return (
+    <div className='col-md-12 no-side-padding custom-markdown'>
+      <ReactMarkdown
+        escapeHtml={false}
+        remarkPlugins={[gfm]}
+        components={{
+          a: renderLink,
+          h1: renderHeading(1),
+          h2: renderHeading(2),
+          h3: renderHeading(3),
+          h4: renderHeading(4),
+          h5: renderHeading(5),
+          h6: renderHeading(6)
+        }}
+      >
+        {normalizedMarkdown}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+export default ChangelogMarkdown;

--- a/src/components/common/ConceptContainerVersionList.jsx
+++ b/src/components/common/ConceptContainerVersionList.jsx
@@ -1,9 +1,13 @@
+/* eslint-disable spellcheck/spell-checker */
 import React from 'react';
 import { Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown'
+import gfm from 'remark-gfm'
 import alertifyjs from 'alertifyjs';
 import {
   Accordion, AccordionSummary, AccordionDetails, Typography, Divider, Tooltip,
-  IconButton, CircularProgress, Chip
+  IconButton, CircularProgress, Chip, Dialog, DialogActions, DialogContent,
+  DialogTitle, Button, Box
 } from '@mui/material';
 import { map, isEmpty, startCase, get, includes, merge } from 'lodash';
 import {
@@ -12,6 +16,10 @@ import {
   NewReleases as ReleaseIcon, FileCopy as CopyIcon,
   Functions as SummaryIcon
 } from '@mui/icons-material';
+import NewspaperIcon from '@mui/icons-material/Newspaper';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import './CustomMarkdown.scss'
 import APIService from '../../services/APIService';
 import { headFirst, copyURL, toFullAPIURL } from '../../common/utils';
 import LastUpdatedOnLabel from './LastUpdatedOnLabel';
@@ -91,11 +99,130 @@ const handleResponse = (response, resource, action, successCallback) => {
 const getService = version => APIService.new().overrideURL(version.version_url)
 const deleteVersion = version => getService(version).delete().then(response => handleResponse(response, version.type, 'Deleted'))
 const updateVersion = (version, data, verb, successCallback) => getService(version).put(data).then(response => handleResponse(response, version.type, verb, updatedVersion => successCallback(merge(version, updatedVersion))))
+const getVersionURI = version => get(version, 'uri') || get(version, 'version_url') || get(version, 'url');
+const isHeadVersion = version => (get(version, 'id') || get(version, 'version') || '').toLowerCase() === 'head';
+
+const getNodeText = children => React.Children.toArray(children).map(child => {
+  if(typeof child === 'string')
+    return child
+  return getNodeText(get(child, 'props.children', ''))
+}).join('')
+
+const slugifyHeading = text => text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-')
+
+const normalizeChangelogMarkdown = markdown => {
+  const headings = []
+  let pendingAnchor = null
+  const markdownWithInlineAnchors = (markdown || '').replace(
+    /<a\s+id=["']([^"']+)["']><\/a>(\[[^\]]+\]\([^)]+\))/gi,
+    (_, id, link) => link.replace(/\)$/, ` "anchor:${id}")`)
+  )
+  const normalizedMarkdown = markdownWithInlineAnchors.split('\n').filter(line => {
+    const anchorMatch = line.trim().match(/^<a\s+id=["']([^"']+)["']><\/a>$/i)
+    if(anchorMatch) {
+      pendingAnchor = anchorMatch[1]
+      return false
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/)
+    if(headingMatch) {
+      headings.push({level: headingMatch[1].length, id: pendingAnchor})
+      pendingAnchor = null
+    }
+
+    return true
+  }).join('\n')
+
+  return {markdown: normalizedMarkdown, headings}
+}
+
+const ChangelogMarkdown = ({markdown}) => {
+  const {markdown: normalizedMarkdown, headings} = React.useMemo(() => normalizeChangelogMarkdown(markdown), [markdown])
+  let headingIndex = 0
+  const renderHeading = level => props => {
+    const children = props.children
+    const rest = {...props}
+    delete rest.node
+    delete rest.children
+    const heading = headings[headingIndex] || {}
+    const Tag = `h${level}`
+    const id = heading.id || slugifyHeading(getNodeText(children))
+    headingIndex += 1
+
+    return <Tag id={id || undefined} style={id ? {scrollMarginTop: '16px'} : {}} {...rest}>{children}</Tag>
+  }
+  const renderLink = props => {
+    const {href, children, title} = props
+    const rest = {...props}
+    delete rest.node
+    delete rest.href
+    delete rest.children
+    delete rest.title
+    const anchor = title && title.startsWith('anchor:') ? title.replace('anchor:', '') : null
+    if(href && href.startsWith('#')) {
+      return (
+        <a
+          href={href}
+          {...rest}
+          onClick={event => {
+            const target = document.getElementById(href.slice(1))
+            if(target) {
+              event.preventDefault()
+              target.scrollIntoView({behavior: 'smooth', block: 'start'})
+            }
+          }}
+        >
+          {children}
+        </a>
+      )
+    }
+
+    if(href && href.match(/^https?:\/\//i))
+      return <a id={anchor || undefined} href={href} target='_blank' rel='noopener noreferrer' {...rest}>{children}</a>
+
+    return <a id={anchor || undefined} href={href} {...rest}>{children}</a>
+  }
+
+  return (
+    <div className='col-md-12 no-side-padding custom-markdown'>
+      <ReactMarkdown
+        escapeHtml={false}
+        remarkPlugins={[gfm]}
+        components={{
+          a: renderLink,
+          h1: renderHeading(1),
+          h2: renderHeading(2),
+          h3: renderHeading(3),
+          h4: renderHeading(4),
+          h5: renderHeading(5),
+          h6: renderHeading(6)
+        }}
+      >
+        {normalizedMarkdown}
+      </ReactMarkdown>
+    </div>
+  )
+}
 
 const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fhir, isLoading }) => {
   const sortedVersions = headFirst(versions);
   const [versionForm, setVersionForm] = React.useState(false);
   const [selectedVersion, setSelectedVersion] = React.useState();
+  const [changelogDialog, setChangelogDialog] = React.useState(false);
+  const [changelogVersion, setChangelogVersion] = React.useState();
+  const [previousChangelogVersion, setPreviousChangelogVersion] = React.useState();
+  const [changelogMarkdown, setChangelogMarkdown] = React.useState('');
+  const [isChangelogLoading, setIsChangelogLoading] = React.useState(false);
+  const [changelogError, setChangelogError] = React.useState('');
+  const [isChangelogFullScreen, setIsChangelogFullScreen] = React.useState(false);
+  const [showChangelogLoadingMessage, setShowChangelogLoadingMessage] = React.useState(false);
+  const changelogLoadingTimer = React.useRef(null);
+
+  React.useEffect(() => () => {
+    if(changelogLoadingTimer.current)
+      clearTimeout(changelogLoadingTimer.current)
+  }, [])
+
   const onEditClick = version => {
     setSelectedVersion(version)
     setVersionForm(true)
@@ -137,6 +264,71 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
     })
   }
 
+  const getPreviousVersion = version => {
+    if(resource !== 'source' || fhir || isHeadVersion(version))
+      return null
+
+    const displayedSourceVersions = sortedVersions.filter(item => !isHeadVersion(item) && getVersionURI(item))
+    const currentIndex = displayedSourceVersions.findIndex(item => getVersionURI(item) === getVersionURI(version))
+
+    return currentIndex > -1 ? displayedSourceVersions[currentIndex + 1] : null
+  }
+
+  const onChangelogClick = version => {
+    const previousVersion = getPreviousVersion(version)
+    if(!previousVersion)
+      return
+
+    if(changelogLoadingTimer.current)
+      clearTimeout(changelogLoadingTimer.current)
+
+    setChangelogDialog(true)
+    setChangelogVersion(version)
+    setPreviousChangelogVersion(previousVersion)
+    setChangelogMarkdown('')
+    setChangelogError('')
+    setIsChangelogLoading(true)
+    setShowChangelogLoadingMessage(false)
+    changelogLoadingTimer.current = setTimeout(() => setShowChangelogLoadingMessage(true), 10000)
+
+    APIService.new()
+      .overrideURL('/sources/$changelog/')
+      .post(
+        {
+          version1: getVersionURI(previousVersion),
+          version2: getVersionURI(version),
+          verbosity: 4
+        },
+        null,
+        null,
+        {inline: true, output: 'markdown', verbosity: 4}
+      )
+      .then(response => {
+        const markdown = get(response, 'data.markdown') || get(response, 'markdown')
+
+        if(markdown) {
+          setChangelogMarkdown(markdown)
+          setChangelogError('')
+        } else {
+          setChangelogError(get(response, 'detail') || get(response, 'error') || 'Could not load changelog.')
+        }
+      })
+      .catch(() => setChangelogError('Could not load changelog.'))
+      .finally(() => {
+        if(changelogLoadingTimer.current)
+          clearTimeout(changelogLoadingTimer.current)
+        setIsChangelogLoading(false)
+      })
+  }
+
+  const onChangelogClose = () => {
+    if(changelogLoadingTimer.current)
+      clearTimeout(changelogLoadingTimer.current)
+    setChangelogDialog(false)
+    setIsChangelogFullScreen(false)
+    setShowChangelogLoadingMessage(false)
+  }
+
 
   return (
     <div className='col-md-12'>
@@ -159,7 +351,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
                 isEmpty(sortedVersions) ?
                 None() :
                 map(sortedVersions, (version, index) => {
-                  const isHEAD = version.id.toLowerCase() === 'head';
+                  const isHEAD = isHeadVersion(version);
                   return (
                     <div className='col-md-12 no-side-padding' key={index}>
                       <div className='col-md-12 no-side-padding flex-vertical-center' style={{margin: '10px 0'}}>
@@ -256,6 +448,14 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
                             {
                               !fhir &&
                               <React.Fragment>
+                                {
+                                  getPreviousVersion(version) &&
+                                  <Tooltip arrow title='Changelog'>
+                                    <IconButton onClick={() => onChangelogClick(version)} size='small'>
+                                      <NewspaperIcon fontSize='inherit' />
+                                    </IconButton>
+                                  </Tooltip>
+                                }
                                 <Tooltip arrow title='Explore Version'>
                                   <IconButton href={`#${version.concepts_url}`} color='primary' size='small'>
                                     <SearchIcon fontSize='inherit' />
@@ -293,6 +493,47 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
           <ConceptContainerVersionForm onCancel={onEditCancel} edit parentURL={get(selectedVersion, 'version_url')} version={selectedVersion} onSubmit={onUpdate} resource={resource} />
         }
       />
+      <Dialog open={changelogDialog} onClose={onChangelogClose} maxWidth='lg' fullWidth fullScreen={isChangelogFullScreen}>
+        <DialogTitle>
+          <Box className='flex-vertical-center' sx={{justifyContent: 'space-between'}}>
+            <span>
+              {`Changelog: ${get(previousChangelogVersion, 'version') || get(previousChangelogVersion, 'id')} -> ${get(changelogVersion, 'version') || get(changelogVersion, 'id')}`}
+            </span>
+            <Tooltip arrow title={isChangelogFullScreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+              <IconButton onClick={() => setIsChangelogFullScreen(!isChangelogFullScreen)} size='small'>
+                {isChangelogFullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </DialogTitle>
+        <DialogContent dividers sx={{height: isChangelogFullScreen ? 'calc(100vh - 132px)' : '70vh', overflow: 'auto'}}>
+          {
+            isChangelogLoading &&
+            <Box sx={{display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column', minHeight: '240px'}}>
+              <CircularProgress color='primary' />
+              {
+                showChangelogLoadingMessage &&
+                <Box sx={{mt: 2, maxWidth: '520px', textAlign: 'center', color: 'text.secondary'}}>
+                  If the source is large, processing may take a while. Please wait patiently.
+                </Box>
+              }
+            </Box>
+          }
+          {
+            !isChangelogLoading && changelogError &&
+            <Box sx={{color: 'error.main', p: 2}}>
+              {changelogError}
+            </Box>
+          }
+          {
+            !isChangelogLoading && !changelogError && changelogMarkdown &&
+            <ChangelogMarkdown markdown={changelogMarkdown} />
+          }
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onChangelogClose}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/common/ConceptContainerVersionList.jsx
+++ b/src/components/common/ConceptContainerVersionList.jsx
@@ -1,8 +1,6 @@
 /* eslint-disable spellcheck/spell-checker */
 import React from 'react';
 import { Link } from 'react-router-dom';
-import ReactMarkdown from 'react-markdown'
-import gfm from 'remark-gfm'
 import alertifyjs from 'alertifyjs';
 import {
   Accordion, AccordionSummary, AccordionDetails, Typography, Divider, Tooltip,
@@ -19,7 +17,6 @@ import {
 import NewspaperIcon from '@mui/icons-material/Newspaper';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
-import './CustomMarkdown.scss'
 import APIService from '../../services/APIService';
 import { headFirst, copyURL, toFullAPIURL } from '../../common/utils';
 import LastUpdatedOnLabel from './LastUpdatedOnLabel';
@@ -28,6 +25,7 @@ import ConceptContainerTip from './ConceptContainerTip';
 import ConceptContainerVersionForm from './ConceptContainerVersionForm';
 import CommonFormDrawer from './CommonFormDrawer';
 import ConceptContainerExport from './ConceptContainerExport';
+import ChangelogMarkdown from './ChangelogMarkdown';
 import { CONCEPT_CONTAINER_RESOURCE_CHILDREN_TAGS } from '../search/ResultConstants';
 
 const ACCORDIAN_HEADING_STYLES = {
@@ -100,108 +98,11 @@ const getService = version => APIService.new().overrideURL(version.version_url)
 const deleteVersion = version => getService(version).delete().then(response => handleResponse(response, version.type, 'Deleted'))
 const updateVersion = (version, data, verb, successCallback) => getService(version).put(data).then(response => handleResponse(response, version.type, verb, updatedVersion => successCallback(merge(version, updatedVersion))))
 const getVersionURI = version => get(version, 'uri') || get(version, 'version_url') || get(version, 'url');
+const getPreviousVersionURI = version => get(version, 'previous_version_url');
 const isHeadVersion = version => (get(version, 'id') || get(version, 'version') || '').toLowerCase() === 'head';
-
-const getNodeText = children => React.Children.toArray(children).map(child => {
-  if(typeof child === 'string')
-    return child
-  return getNodeText(get(child, 'props.children', ''))
-}).join('')
-
-const slugifyHeading = text => text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-')
-
-const normalizeChangelogMarkdown = markdown => {
-  const headings = []
-  let pendingAnchor = null
-  const markdownWithInlineAnchors = (markdown || '').replace(
-    /<a\s+id=["']([^"']+)["']><\/a>(\[[^\]]+\]\([^)]+\))/gi,
-    (_, id, link) => link.replace(/\)$/, ` "anchor:${id}")`)
-  )
-  const normalizedMarkdown = markdownWithInlineAnchors.split('\n').filter(line => {
-    const anchorMatch = line.trim().match(/^<a\s+id=["']([^"']+)["']><\/a>$/i)
-    if(anchorMatch) {
-      pendingAnchor = anchorMatch[1]
-      return false
-    }
-
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/)
-    if(headingMatch) {
-      headings.push({level: headingMatch[1].length, id: pendingAnchor})
-      pendingAnchor = null
-    }
-
-    return true
-  }).join('\n')
-
-  return {markdown: normalizedMarkdown, headings}
-}
-
-const ChangelogMarkdown = ({markdown}) => {
-  const {markdown: normalizedMarkdown, headings} = React.useMemo(() => normalizeChangelogMarkdown(markdown), [markdown])
-  let headingIndex = 0
-  const renderHeading = level => props => {
-    const children = props.children
-    const rest = {...props}
-    delete rest.node
-    delete rest.children
-    const heading = headings[headingIndex] || {}
-    const Tag = `h${level}`
-    const id = heading.id || slugifyHeading(getNodeText(children))
-    headingIndex += 1
-
-    return <Tag id={id || undefined} style={id ? {scrollMarginTop: '16px'} : {}} {...rest}>{children}</Tag>
-  }
-  const renderLink = props => {
-    const {href, children, title} = props
-    const rest = {...props}
-    delete rest.node
-    delete rest.href
-    delete rest.children
-    delete rest.title
-    const anchor = title && title.startsWith('anchor:') ? title.replace('anchor:', '') : null
-    if(href && href.startsWith('#')) {
-      return (
-        <a
-          href={href}
-          {...rest}
-          onClick={event => {
-            const target = document.getElementById(href.slice(1))
-            if(target) {
-              event.preventDefault()
-              target.scrollIntoView({behavior: 'smooth', block: 'start'})
-            }
-          }}
-        >
-          {children}
-        </a>
-      )
-    }
-
-    if(href && href.match(/^https?:\/\//i))
-      return <a id={anchor || undefined} href={href} target='_blank' rel='noopener noreferrer' {...rest}>{children}</a>
-
-    return <a id={anchor || undefined} href={href} {...rest}>{children}</a>
-  }
-
-  return (
-    <div className='col-md-12 no-side-padding custom-markdown'>
-      <ReactMarkdown
-        escapeHtml={false}
-        remarkPlugins={[gfm]}
-        components={{
-          a: renderLink,
-          h1: renderHeading(1),
-          h2: renderHeading(2),
-          h3: renderHeading(3),
-          h4: renderHeading(4),
-          h5: renderHeading(5),
-          h6: renderHeading(6)
-        }}
-      >
-        {normalizedMarkdown}
-      </ReactMarkdown>
-    </div>
-  )
+const getVersionLabelFromURL = url => {
+  const parts = (url || '').split('/').filter(Boolean)
+  return parts[parts.length - 1] || url
 }
 
 const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fhir, isLoading }) => {
@@ -210,7 +111,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
   const [selectedVersion, setSelectedVersion] = React.useState();
   const [changelogDialog, setChangelogDialog] = React.useState(false);
   const [changelogVersion, setChangelogVersion] = React.useState();
-  const [previousChangelogVersion, setPreviousChangelogVersion] = React.useState();
+  const [previousChangelogVersionURL, setPreviousChangelogVersionURL] = React.useState();
   const [changelogMarkdown, setChangelogMarkdown] = React.useState('');
   const [isChangelogLoading, setIsChangelogLoading] = React.useState(false);
   const [changelogError, setChangelogError] = React.useState('');
@@ -264,19 +165,16 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
     })
   }
 
-  const getPreviousVersion = version => {
+  const getChangelogPreviousVersionURL = version => {
     if(resource !== 'source' || fhir || isHeadVersion(version))
       return null
 
-    const displayedSourceVersions = sortedVersions.filter(item => !isHeadVersion(item) && getVersionURI(item))
-    const currentIndex = displayedSourceVersions.findIndex(item => getVersionURI(item) === getVersionURI(version))
-
-    return currentIndex > -1 ? displayedSourceVersions[currentIndex + 1] : null
+    return getPreviousVersionURI(version)
   }
 
   const onChangelogClick = version => {
-    const previousVersion = getPreviousVersion(version)
-    if(!previousVersion)
+    const previousVersionURL = getChangelogPreviousVersionURL(version)
+    if(!previousVersionURL)
       return
 
     if(changelogLoadingTimer.current)
@@ -284,7 +182,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
 
     setChangelogDialog(true)
     setChangelogVersion(version)
-    setPreviousChangelogVersion(previousVersion)
+    setPreviousChangelogVersionURL(previousVersionURL)
     setChangelogMarkdown('')
     setChangelogError('')
     setIsChangelogLoading(true)
@@ -295,7 +193,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
       .overrideURL('/sources/$changelog/')
       .post(
         {
-          version1: getVersionURI(previousVersion),
+          version1: previousVersionURL,
           version2: getVersionURI(version),
           verbosity: 4
         },
@@ -449,7 +347,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
                               !fhir &&
                               <React.Fragment>
                                 {
-                                  getPreviousVersion(version) &&
+                                  getChangelogPreviousVersionURL(version) &&
                                   <Tooltip arrow title='Changelog'>
                                     <IconButton onClick={() => onChangelogClick(version)} size='small'>
                                       <NewspaperIcon fontSize='inherit' />
@@ -497,7 +395,7 @@ const ConceptContainerVersionList = ({ versions, resource, canEdit, onUpdate, fh
         <DialogTitle>
           <Box className='flex-vertical-center' sx={{justifyContent: 'space-between'}}>
             <span>
-              {`Changelog: ${get(previousChangelogVersion, 'version') || get(previousChangelogVersion, 'id')} -> ${get(changelogVersion, 'version') || get(changelogVersion, 'id')}`}
+              {`Changelog: ${getVersionLabelFromURL(previousChangelogVersionURL)} -> ${get(changelogVersion, 'version') || get(changelogVersion, 'id')}`}
             </span>
             <Tooltip arrow title={isChangelogFullScreen ? 'Exit Fullscreen' : 'Fullscreen'}>
               <IconButton onClick={() => setIsChangelogFullScreen(!isChangelogFullScreen)} size='small'>


### PR DESCRIPTION
## Summary

- Adds a Changelog button (newspaper icon) to each source version row in `ConceptContainerVersionList`. The button is only displayed for non-HEAD versions that have a previous version available for comparison.

- Clicking the button opens a Material UI dialog that fetches and renders a markdown changelog between the selected version and its immediate predecessor using the `/sources/$changelog/` endpoint with:
  - `verbosity=4`
  - `output=markdown`

- Introduces a `ChangelogMarkdown` renderer using `ReactMarkdown` + `remark-gfm`, including custom handling for:
  - anchor-tagged headings (`<a id="..."></a>`) normalized into proper heading IDs
  - smooth scrolling for in-page `#` links
  - external links automatically opened in a new tab

- The dialog supports fullscreen mode and displays a patience/loading message after 10 seconds if the changelog is still processing.

- Refactors HEAD version detection into a shared `isHeadVersion` helper for consistency across the application.

- Adds `CustomMarkdown.scss` to provide markdown-specific styling for changelog rendering.