### PR TITLE
Fix Version Pagination and Changelog Logic

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -144,6 +144,39 @@ export const toOwnerURI = uri => uri ? uri.split('/').splice(0, 3).join('/') + '
 
 export const headFirst = versions => compact([find(versions, version => (version.version || version.id) === 'HEAD'), ...reject(versions, version => (version.version || version.id) === 'HEAD')]);
 
+export const hasNextVersionsPage = (response, versions) => {
+  const { next, pages, page_number } = response.headers || {};
+  const pageNumber = parseInt(page_number);
+  const pageCount = parseInt(pages);
+  const hasPaginationHeaders = next || (!isNaN(pageNumber) && !isNaN(pageCount));
+
+  if(hasPaginationHeaders)
+    return Boolean(next) || pageNumber < pageCount;
+
+  const lastVersion = last(versions || []);
+  return Boolean(lastVersion && lastVersion.previous_version_url);
+}
+
+export const fetchAllVersions = (url, query = {}) => {
+  const fetchPage = (page = 1, accumulatedVersions = []) => (
+    APIService
+      .new()
+      .overrideURL(url)
+      .get(null, null, {...query, limit: get(query, 'limit', 1000), page: page})
+      .then(response => {
+        const newVersions = response.data || [];
+        const allVersions = [...accumulatedVersions, ...newVersions];
+
+        if(hasNextVersionsPage(response, newVersions))
+          return fetchPage(page + 1, allVersions);
+
+        return allVersions;
+      })
+  );
+
+  return fetchPage();
+}
+
 export const currentUserToken = () => localStorage.token;
 
 export const isLoggedIn = () => Boolean(currentUserToken());

--- a/src/components/collections/CollectionHome.jsx
+++ b/src/components/collections/CollectionHome.jsx
@@ -12,7 +12,7 @@ import ConceptHome from '../concepts/ConceptHome';
 import MappingHome from '../mappings/MappingHome';
 import ResponsiveDrawer from '../common/ResponsiveDrawer';
 import Breadcrumbs from '../sources/Breadcrumbs';
-import { paramsToURI, paramsToParentURI } from '../../common/utils';
+import { fetchAllVersions, paramsToURI, paramsToParentURI } from '../../common/utils';
 import { OperationsContext } from '../app/LayoutContext';
 
 const TABS = ['details', 'concepts', 'mappings', 'references', 'versions', 'summary', 'about']
@@ -157,23 +157,9 @@ class CollectionHome extends React.Component {
     return urls
   }
 
-  getVersions(page = 1, accumulatedVersions = []) {
-    APIService
-      .new()
-      .overrideURL(this.collectionPath + 'versions/')
-      .get(null, null, {limit: 1000, page: page, brief: true})
-      .then(response => {
-        const newVersions = response.data || []
-        const allVersions = [...accumulatedVersions, ...newVersions]
-        const { next, pages, page_number } = response.headers || {}
-        const hasNext = next || (parseInt(page_number) < parseInt(pages))
-
-        if (hasNext) {
-          this.getVersions(page + 1, allVersions)
-        } else {
-          this.setState({versions: allVersions})
-        }
-      })
+  getVersions() {
+    fetchAllVersions(this.collectionPath + 'versions/', {brief: true})
+      .then(versions => this.setState({versions: versions}))
   }
 
   getExpansions() {

--- a/src/components/collections/CollectionHome.jsx
+++ b/src/components/collections/CollectionHome.jsx
@@ -157,12 +157,23 @@ class CollectionHome extends React.Component {
     return urls
   }
 
-  getVersions() {
+  getVersions(page = 1, accumulatedVersions = []) {
     APIService
       .new()
       .overrideURL(this.collectionPath + 'versions/')
-      .get(null, null, {limit: 1000, brief: true})
-      .then(response => this.setState({versions: response.data}))
+      .get(null, null, {limit: 1000, page: page, brief: true})
+      .then(response => {
+        const newVersions = response.data || []
+        const allVersions = [...accumulatedVersions, ...newVersions]
+        const { next, pages, page_number } = response.headers || {}
+        const hasNext = next || (parseInt(page_number) < parseInt(pages))
+
+        if (hasNext) {
+          this.getVersions(page + 1, allVersions)
+        } else {
+          this.setState({versions: allVersions})
+        }
+      })
   }
 
   getExpansions() {

--- a/src/components/collections/ResourceReferenceForm.jsx
+++ b/src/components/collections/ResourceReferenceForm.jsx
@@ -6,6 +6,7 @@ import MixedOwnersAutocomplete from '../common/MixedOwnersAutocomplete';
 import ConceptContainersAutocomplete from '../common/ConceptContainersAutocomplete';
 import APIService from '../../services/APIService';
 import Search from '../search/Search';
+import { fetchAllVersions } from '../../common/utils';
 
 class ResourceReferenceForm extends React.Component {
   constructor(props) {
@@ -75,26 +76,12 @@ class ResourceReferenceForm extends React.Component {
     }
   }
 
-  fetchVersions(page = 1, accumulatedVersions = []) {
+  fetchVersions() {
     const { source, collection } = this.state;
     const container = source || collection;
     if(container) {
-      APIService.new()
-                .overrideURL(container.url)
-                .appendToUrl('versions/')
-                .get(null, null, {limit: 1000, page: page})
-                .then(response => {
-                  const newVersions = response.data || []
-                  const allVersions = [...accumulatedVersions, ...newVersions]
-                  const { next, pages, page_number } = response.headers || {}
-                  const hasNext = next || (parseInt(page_number) < parseInt(pages))
-
-                  if (hasNext) {
-                    this.fetchVersions(page + 1, allVersions)
-                  } else {
-                    this.setState({versions: allVersions})
-                  }
-                })
+      fetchAllVersions(container.url + 'versions/')
+        .then(versions => this.setState({versions: versions}))
     }
   }
 

--- a/src/components/collections/ResourceReferenceForm.jsx
+++ b/src/components/collections/ResourceReferenceForm.jsx
@@ -75,11 +75,26 @@ class ResourceReferenceForm extends React.Component {
     }
   }
 
-  fetchVersions() {
+  fetchVersions(page = 1, accumulatedVersions = []) {
     const { source, collection } = this.state;
     const container = source || collection;
     if(container) {
-      APIService.new().overrideURL(container.url).appendToUrl('versions/').get().then(response => this.setState({versions: response.data}))
+      APIService.new()
+                .overrideURL(container.url)
+                .appendToUrl('versions/')
+                .get(null, null, {limit: 1000, page: page})
+                .then(response => {
+                  const newVersions = response.data || []
+                  const allVersions = [...accumulatedVersions, ...newVersions]
+                  const { next, pages, page_number } = response.headers || {}
+                  const hasNext = next || (parseInt(page_number) < parseInt(pages))
+
+                  if (hasNext) {
+                    this.fetchVersions(page + 1, allVersions)
+                  } else {
+                    this.setState({versions: allVersions})
+                  }
+                })
     }
   }
 

--- a/src/components/concepts/ConceptHome.jsx
+++ b/src/components/concepts/ConceptHome.jsx
@@ -4,7 +4,7 @@ import Split from 'react-split'
 import { CircularProgress } from '@mui/material';
 import { get, isObject, isBoolean, has, flatten, values, isArray, find, map } from 'lodash';
 import APIService from '../../services/APIService';
-import { toParentURI, currentUserHasAccess, recordGAAction, highlightTexts } from '../../common/utils'
+import { fetchAllVersions, toParentURI, currentUserHasAccess, recordGAAction, highlightTexts } from '../../common/utils'
 import NotFound from '../common/NotFound';
 import AccessDenied from '../common/AccessDenied';
 import PermissionDenied from '../common/PermissionDenied';
@@ -195,21 +195,11 @@ class ConceptHome extends React.Component {
                                                       .get()
                                                       .then(response => callback(response.data))
 
-  getVersions(page = 1, accumulatedVersions = []) {
-    APIService.new()
-              .overrideURL(encodeURI(this.getVersionedObjectURLFromPath()) + 'versions/')
-              .get(null, null, {limit: 1000, page: page, includeCollectionVersions: true, includeSourceVersions: true})
-              .then(response => {
-                const newVersions = response.data || []
-                const allVersions = [...accumulatedVersions, ...newVersions]
-                const lastVersion = newVersions[newVersions.length - 1]
-
-                if (lastVersion && lastVersion.previous_version_url) {
-                  this.getVersions(page + 1, allVersions)
-                } else {
-                  this.setState({versions: allVersions})
-                }
-              })
+  getVersions() {
+    fetchAllVersions(
+      encodeURI(this.getVersionedObjectURLFromPath()) + 'versions/',
+      {includeCollectionVersions: true, includeSourceVersions: true}
+    ).then(versions => this.setState({versions: versions}))
   }
 
   getMappings = directOnly => {

--- a/src/components/concepts/ConceptHome.jsx
+++ b/src/components/concepts/ConceptHome.jsx
@@ -195,12 +195,20 @@ class ConceptHome extends React.Component {
                                                       .get()
                                                       .then(response => callback(response.data))
 
-  getVersions() {
+  getVersions(page = 1, accumulatedVersions = []) {
     APIService.new()
               .overrideURL(encodeURI(this.getVersionedObjectURLFromPath()) + 'versions/')
-              .get(null, null, {includeCollectionVersions: true, includeSourceVersions: true})
+              .get(null, null, {limit: 1000, page: page, includeCollectionVersions: true, includeSourceVersions: true})
               .then(response => {
-                this.setState({versions: response.data})
+                const newVersions = response.data || []
+                const allVersions = [...accumulatedVersions, ...newVersions]
+                const lastVersion = newVersions[newVersions.length - 1]
+
+                if (lastVersion && lastVersion.previous_version_url) {
+                  this.getVersions(page + 1, allVersions)
+                } else {
+                  this.setState({versions: allVersions})
+                }
               })
   }
 

--- a/src/components/mappings/MappingHome.jsx
+++ b/src/components/mappings/MappingHome.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CircularProgress } from '@mui/material';
 import { get, isObject, has } from 'lodash';
 import APIService from '../../services/APIService';
-import { recordGAAction, highlightTexts } from '../../common/utils'
+import { fetchAllVersions, recordGAAction, highlightTexts } from '../../common/utils'
 import ScopeHeader from './ScopeHeader'
 import MappingHomeDetails from './MappingHomeDetails';
 import NotFound from '../common/NotFound';
@@ -92,21 +92,11 @@ class MappingHome extends React.Component {
 
   highlightFromSearch = () => this.props.searchMeta && setTimeout(() => highlightTexts([{...this.state.mapping, search_meta: this.props.searchMeta}]), 100)
 
-  getVersions(page = 1, accumulatedVersions = []) {
-    APIService.new()
-              .overrideURL(this.getVersionedObjectURLFromPath() + 'versions/')
-              .get(null, null, {limit: 1000, page: page, includeCollectionVersions: true, includeSourceVersions: true})
-              .then(response => {
-                const newVersions = response.data || []
-                const allVersions = [...accumulatedVersions, ...newVersions]
-                const lastVersion = newVersions[newVersions.length - 1]
-
-                if (lastVersion && lastVersion.previous_version_url) {
-                  this.getVersions(page + 1, allVersions)
-                } else {
-                  this.setState({versions: allVersions})
-                }
-              })
+  getVersions() {
+    fetchAllVersions(
+      this.getVersionedObjectURLFromPath() + 'versions/',
+      {includeCollectionVersions: true, includeSourceVersions: true}
+    ).then(versions => this.setState({versions: versions}))
   }
 
   getCollectionVersions() {

--- a/src/components/mappings/MappingHome.jsx
+++ b/src/components/mappings/MappingHome.jsx
@@ -92,12 +92,20 @@ class MappingHome extends React.Component {
 
   highlightFromSearch = () => this.props.searchMeta && setTimeout(() => highlightTexts([{...this.state.mapping, search_meta: this.props.searchMeta}]), 100)
 
-  getVersions() {
+  getVersions(page = 1, accumulatedVersions = []) {
     APIService.new()
               .overrideURL(this.getVersionedObjectURLFromPath() + 'versions/')
-              .get(null, null, {includeCollectionVersions: true, includeSourceVersions: true})
+              .get(null, null, {limit: 1000, page: page, includeCollectionVersions: true, includeSourceVersions: true})
               .then(response => {
-                this.setState({versions: response.data})
+                const newVersions = response.data || []
+                const allVersions = [...accumulatedVersions, ...newVersions]
+                const lastVersion = newVersions[newVersions.length - 1]
+
+                if (lastVersion && lastVersion.previous_version_url) {
+                  this.getVersions(page + 1, allVersions)
+                } else {
+                  this.setState({versions: allVersions})
+                }
               })
   }
 

--- a/src/components/search/ResultsTable.jsx
+++ b/src/components/search/ResultsTable.jsx
@@ -480,7 +480,7 @@ const ExpandibleRow = props => {
     return '/' + compact(get(ident, 'value', '').split('/')).splice(0, 4).join('/')
   };
 
-  const fetchVersions = () => {
+  const fetchVersions = (page = 1, accumulated = []) => {
     if(fhir) {
       if(hapi) {
         const baseURI = get(getAppliedServerConfig(), 'info.baseURI')
@@ -504,10 +504,19 @@ const ExpandibleRow = props => {
       if(item.url) {
         APIService.new().overrideURL(item.url)
                   .appendToUrl('versions/')
-                  .get()
+                  .get(null, null, {limit: 1000, page: page})
                   .then(response => {
-                    if(response.status === 200)
-                      setVersions(response.data)
+                    if(response.status === 200) {
+                      const allVersions = [...accumulated, ...response.data]
+                      const { next, pages, page_number } = response.headers || {}
+                      const hasNext = next || (parseInt(page_number) < parseInt(pages))
+
+                      if (hasNext) {
+                        fetchVersions(page + 1, allVersions)
+                      } else {
+                        setVersions(allVersions)
+                      }
+                    }
                   })
       }
     }

--- a/src/components/search/ResultsTable.jsx
+++ b/src/components/search/ResultsTable.jsx
@@ -27,6 +27,7 @@ import {
 import {
   formatDateTime, headFirst, isLoggedIn, defaultCreatePin, defaultDeletePin,
   getCurrentUserUsername, isCurrentUserMemberOf, isAdminUser, currentUserHasAccess, getAppliedServerConfig,
+  fetchAllVersions,
 } from '../../common/utils';
 import ReleasedChip from '../common/ReleasedChip';
 import AllMappingsTables from '../mappings/AllMappingsTables';
@@ -480,7 +481,7 @@ const ExpandibleRow = props => {
     return '/' + compact(get(ident, 'value', '').split('/')).splice(0, 4).join('/')
   };
 
-  const fetchVersions = (page = 1, accumulated = []) => {
+  const fetchVersions = () => {
     if(fhir) {
       if(hapi) {
         const baseURI = get(getAppliedServerConfig(), 'info.baseURI')
@@ -502,22 +503,8 @@ const ExpandibleRow = props => {
       }
     } else {
       if(item.url) {
-        APIService.new().overrideURL(item.url)
-                  .appendToUrl('versions/')
-                  .get(null, null, {limit: 1000, page: page})
-                  .then(response => {
-                    if(response.status === 200) {
-                      const allVersions = [...accumulated, ...response.data]
-                      const { next, pages, page_number } = response.headers || {}
-                      const hasNext = next || (parseInt(page_number) < parseInt(pages))
-
-                      if (hasNext) {
-                        fetchVersions(page + 1, allVersions)
-                      } else {
-                        setVersions(allVersions)
-                      }
-                    }
-                  })
+        fetchAllVersions(item.url + 'versions/')
+          .then(versions => setVersions(versions))
       }
     }
   }

--- a/src/components/sources/SourceHome.jsx
+++ b/src/components/sources/SourceHome.jsx
@@ -111,15 +111,24 @@ class SourceHome extends React.Component {
     }
   }
 
-  getVersions() {
+  getVersions(page = 1, accumulatedVersions = []) {
     this.setState({isLoadingVersions: true}, () => {
       APIService
         .new()
         .overrideURL(this.sourcePath + 'versions/')
-        .get(null, null, {verbose: true, limit: 1000, includeStates: isLoggedIn(), includeSummary: true})
+        .get(null, null, {verbose: true, limit: 1000, page: page, includeStates: isLoggedIn(), includeSummary: true})
         .then(response => {
-          this.setState({versions: response.data, isLoadingVersions: false})
+          const newVersions = response.data || []
+          const allVersions = [...accumulatedVersions, ...newVersions]
+          const lastVersion = newVersions[newVersions.length - 1]
+
+          if (lastVersion && lastVersion.previous_version_url) {
+            this.getVersions(page + 1, allVersions)
+          } else {
+            this.setState({versions: allVersions, isLoadingVersions: false})
+          }
         })
+        .catch(() => this.setState({isLoadingVersions: false}))
     })
   }
 

--- a/src/components/sources/SourceHome.jsx
+++ b/src/components/sources/SourceHome.jsx
@@ -12,7 +12,7 @@ import ConceptHome from '../concepts/ConceptHome';
 import MappingHome from '../mappings/MappingHome';
 import ResponsiveDrawer from '../common/ResponsiveDrawer';
 import { SOURCE_DEFAULT_CONFIG } from "../../common/defaultConfigs"
-import { paramsToURI, paramsToParentURI, isLoggedIn } from '../../common/utils';
+import { fetchAllVersions, paramsToURI, paramsToParentURI, isLoggedIn } from '../../common/utils';
 import { OperationsContext } from '../app/LayoutContext';
 
 const TABS = ['details', 'concepts', 'mappings', 'versions', 'summary', 'about']
@@ -111,23 +111,13 @@ class SourceHome extends React.Component {
     }
   }
 
-  getVersions(page = 1, accumulatedVersions = []) {
+  getVersions() {
     this.setState({isLoadingVersions: true}, () => {
-      APIService
-        .new()
-        .overrideURL(this.sourcePath + 'versions/')
-        .get(null, null, {verbose: true, limit: 1000, page: page, includeStates: isLoggedIn(), includeSummary: true})
-        .then(response => {
-          const newVersions = response.data || []
-          const allVersions = [...accumulatedVersions, ...newVersions]
-          const lastVersion = newVersions[newVersions.length - 1]
-
-          if (lastVersion && lastVersion.previous_version_url) {
-            this.getVersions(page + 1, allVersions)
-          } else {
-            this.setState({versions: allVersions, isLoadingVersions: false})
-          }
-        })
+      fetchAllVersions(
+        this.sourcePath + 'versions/',
+        {verbose: true, includeStates: isLoggedIn(), includeSummary: true}
+      )
+        .then(versions => this.setState({versions: versions, isLoadingVersions: false}))
         .catch(() => this.setState({isLoadingVersions: false}))
     })
   }

--- a/src/components/sources/SourceHomeTabs.jsx
+++ b/src/components/sources/SourceHomeTabs.jsx
@@ -149,6 +149,7 @@ const SourceHomeTabs = props => {
         }
         {
           !isInvalidTabConfig && selectedTabConfig.type === 'versions' &&
+          // TODO update class component to functional component and replace fetchAllVersions with useVersions hook.
           <ConceptContainerVersionList versions={versions} resource='source' canEdit={hasAccess} onUpdate={onVersionUpdate} isLoading={isLoadingVersions} />
         }
         {


### PR DESCRIPTION
## Problem

The OCL API `/versions/` endpoint is paginated by default.

Previously, several frontend components fetched only the first page of version results (typically limited to 25 or 1000 items depending on the component).

For resources with long histories — such as sources, collections, concepts, or mappings — older versions became effectively invisible in the UI.

As a consequence, the oldest version returned on the first fetched page was incorrectly interpreted as the beginning of the history, even when additional historical versions existed on subsequent API pages.

---

## Impact

### 1. Incomplete Version Navigation

Users could not fully navigate resource history through:

- breadcrumbs
- version selectors
- reference forms
- result previews

when the total number of versions exceeded the pagination limit.

---

### 2. Changelog Regressions

The recently added Changelog feature depends on correctly identifying the predecessor version.

Because the frontend loaded only partial history:

- some versions were incorrectly treated as the first version
- the changelog icon appeared when it should not
- clicking the icon resulted in inconsistent or broken behavior because the API still recognized a predecessor version

---

### 3. Repository History Inconsistency

Reference components and search previews displayed incomplete historical state information due to partial pagination loading.

---

## Solution

Refactored version-fetching logic across the application to iteratively fetch all version pages until the absolute first version is reached.

The frontend now continues fetching while:

- pagination indicates a `next` page exists
- or the last fetched version still contains a `previous_version_url`

This guarantees that the UI has complete historical awareness before rendering version-dependent behavior.

---

## Technical Changes

### Recursive / Iterative Fetching

Updated:

- `getVersions`
- `fetchVersions`

across:

- `SourceHome`
- `CollectionHome`
- `ConceptHome`
- `MappingHome`
- `ResourceReferenceForm`
- `ResultsTable`

---

### Correct First-Version Detection

The UI now correctly identifies the absolute first version:

~~~text
previous_version_url === null
~~~

This fixes changelog rendering behavior and prevents invalid changelog actions.

---

### Performance Considerations

- Maintained `limit=1000` where applicable
- minimized unnecessary network round-trips
- ensured correctness without sacrificing usability for large repositories